### PR TITLE
Adds explicit protocol on TileLayer url

### DIFF
--- a/src/services/leafletMapDefaults.js
+++ b/src/services/leafletMapDefaults.js
@@ -23,7 +23,7 @@ angular.module('leaflet-directive').factory('leafletMapDefaults', function($q, l
         server: ' http://nominatim.openstreetmap.org/search',
       },
       crs: L.CRS.EPSG3857,
-      tileLayer: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       tileLayerOptions: {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       },


### PR DESCRIPTION
Without an explicit protocol, IOS built version (cordova) interprets it as file (differently than in browser though), and throws this error:
`Failed to load resource: The requested URL was not found on this server. file://a.tile.openstreetmap.org/12/1135/1736.png`